### PR TITLE
Bump dflydev/dot-access-data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "dflydev/dot-access-data": "^3.0",
+        "dflydev/dot-access-data": "^3.0.1",
         "nette/schema": "^1.2"
     },
     "require-dev": {


### PR DESCRIPTION
This bumps `dflydev/dot-access-data` to the newly released v3.0.1 version: https://github.com/dflydev/dflydev-dot-access-data/releases/tag/v3.0.1

The reason for this is that otherwise builds with the `--prefer-lowest` flag for Composer will break on PHP 8.1. After this gets merged and tagged I'll also send in a PR to `league/commonmark` to do the same thing there.

PS. Let me know if this was the correct branch for this 🤔 