### PR TITLE
Docs code block consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 
 This project requires PHP 7.4 or higher.  To install it via [Composer] simply run:
 
-``` bash
-$ composer require league/config
+```bash
+composer require league/config
 ```
 
 ## 🧰️ Basic Usage

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ Contributions to this library are **welcome**! We only ask that you adhere to ou
 
 ## 🧪 Testing
 
-``` bash
-$ composer test
+```bash
+composer test
 ```
 
 ## 📄 License

--- a/docs/1.0/basic-usage.md
+++ b/docs/1.0/basic-usage.md
@@ -19,8 +19,6 @@ There are three steps to using this library:
 Simply define your configuration schema, set the values, and then fetch them where needed:
 
 ```php
-<?php
-
 use League\Config\Configuration;
 use Nette\Schema\Expect;
 

--- a/docs/1.0/basic-usage.md
+++ b/docs/1.0/basic-usage.md
@@ -28,12 +28,14 @@ $config = new Configuration([
         'driver' => Expect::anyOf('mysql', 'postgresql', 'sqlite')->required(),
         'host' => Expect::string()->default('localhost'),
         'port' => Expect::int()->min(1)->max(65535),
+        'ssl' => Expect::bool(),
         'database' => Expect::string()->required(),
         'username' => Expect::string()->required(),
         'password' => Expect::string()->nullable(),
     ]),
     'logging' => Expect::structure([
         'enabled' => Expect::bool()->default($_ENV['DEBUG'] == true),
+        'file' => Expect::string()->deprecated("use logging.path instead"),
         'path' => Expect::string()->assert(function ($path) { return \is_writeable($path); })->required(),
     ]),
 ]);

--- a/docs/1.1/basic-usage.md
+++ b/docs/1.1/basic-usage.md
@@ -19,8 +19,6 @@ There are three steps to using this library:
 Simply define your configuration schema, set the values, and then fetch them where needed:
 
 ```php
-<?php
-
 use League\Config\Configuration;
 use Nette\Schema\Expect;
 

--- a/docs/1.1/basic-usage.md
+++ b/docs/1.1/basic-usage.md
@@ -28,12 +28,14 @@ $config = new Configuration([
         'driver' => Expect::anyOf('mysql', 'postgresql', 'sqlite')->required(),
         'host' => Expect::string()->default('localhost'),
         'port' => Expect::int()->min(1)->max(65535),
+        'ssl' => Expect::bool(),
         'database' => Expect::string()->required(),
         'username' => Expect::string()->required(),
         'password' => Expect::string()->nullable(),
     ]),
     'logging' => Expect::structure([
         'enabled' => Expect::bool()->default($_ENV['DEBUG'] == true),
+        'file' => Expect::string()->deprecated("use logging.path instead"),
         'path' => Expect::string()->assert(function ($path) { return \is_writeable($path); })->required(),
     ]),
 ]);


### PR DESCRIPTION
Mirroring https://github.com/thephpleague/commonmark/pull/554, I've taken a pass on the docs for consistency on usage not caught by `markdownlint`.

- Remove PHP open tags
- Consistency in primary `$config` object
- Consistency between README & docs