### PR TITLE
Update `github/super-linter`

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: github/super-linter@v3
+      - uses: github/super-linter/slim@v4.8.1
         env:
           DEFAULT_BRANCH: latest
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update `github/super-linter` to use the [slim image](https://github.com/github/super-linter#slim-image) and match the version used by [thephpleague/commonmark](https://github.com/thephpleague/commonmark)

Related: https://github.com/thephpleague/commonmark/pull/733