### PR TITLE
Validate relevant schema only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Updates should follow the [Keep a CHANGELOG](https://keepachangelog.com/) princi
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Values can now be set prior to the corresponding schema being registered.
+- `exists()` and `get()` now only trigger validation for the relevant schema, not the entire config at once.
+
 ## [1.1.1] - 2021-08-14
 
 ### Changed

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace League\Config;
 
 use Dflydev\DotAccessData\Data;
+use Dflydev\DotAccessData\DataInterface;
 use Dflydev\DotAccessData\Exception\DataException;
 use Dflydev\DotAccessData\Exception\InvalidPathException;
 use Dflydev\DotAccessData\Exception\MissingPathException;
@@ -37,7 +38,7 @@ final class Configuration implements ConfigurationBuilderInterface, Configuratio
     private array $configSchemas = [];
 
     /** @psalm-allow-private-mutation */
-    private ?Data $finalConfig = null;
+    private Data $finalConfig;
 
     /**
      * @var array<string, mixed>
@@ -56,6 +57,7 @@ final class Configuration implements ConfigurationBuilderInterface, Configuratio
     {
         $this->configSchemas = $baseSchemas;
         $this->userConfig    = new Data();
+        $this->finalConfig   = new Data();
 
         $this->reader = new ReadOnlyConfiguration($this);
     }
@@ -81,7 +83,7 @@ final class Configuration implements ConfigurationBuilderInterface, Configuratio
     {
         $this->invalidate();
 
-        $this->userConfig->import($config, Data::REPLACE);
+        $this->userConfig->import($config, DataInterface::REPLACE);
     }
 
     /**
@@ -107,13 +109,13 @@ final class Configuration implements ConfigurationBuilderInterface, Configuratio
      */
     public function get(string $key)
     {
-        if ($this->finalConfig === null) {
-            $this->finalConfig = $this->build();
-        } elseif (\array_key_exists($key, $this->cache)) {
+        if (\array_key_exists($key, $this->cache)) {
             return $this->cache[$key];
         }
 
         try {
+            $this->build(self::getTopLevelKey($key));
+
             return $this->cache[$key] = $this->finalConfig->get($key);
         } catch (InvalidPathException | MissingPathException $ex) {
             throw new UnknownOptionException($ex->getMessage(), $key, (int) $ex->getCode(), $ex);
@@ -127,15 +129,15 @@ final class Configuration implements ConfigurationBuilderInterface, Configuratio
      */
     public function exists(string $key): bool
     {
-        if ($this->finalConfig === null) {
-            $this->finalConfig = $this->build();
-        } elseif (\array_key_exists($key, $this->cache)) {
+        if (\array_key_exists($key, $this->cache)) {
             return true;
         }
 
         try {
+            $this->build(self::getTopLevelKey($key));
+
             return $this->finalConfig->has($key);
-        } catch (InvalidPathException $ex) {
+        } catch (InvalidPathException | UnknownOptionException $ex) {
             return false;
         }
     }
@@ -154,29 +156,45 @@ final class Configuration implements ConfigurationBuilderInterface, Configuratio
     private function invalidate(): void
     {
         $this->cache       = [];
-        $this->finalConfig = null;
+        $this->finalConfig = new Data();
     }
 
     /**
      * Applies the schema against the configuration to return the final configuration
      *
-     * @throws ValidationException
+     * @throws ValidationException|UnknownOptionException|InvalidPathException
      *
      * @psalm-allow-private-mutation
      */
-    private function build(): Data
+    private function build(string $topLevelKey): void
     {
+        if ($this->finalConfig->has($topLevelKey)) {
+            return;
+        }
+
+        if (! isset($this->configSchemas[$topLevelKey])) {
+            throw new UnknownOptionException(\sprintf('Missing config schema for "%s"', $topLevelKey), $topLevelKey);
+        }
+
         try {
-            $schema    = Expect::structure($this->configSchemas);
+            $userData = [$topLevelKey => $this->userConfig->get($topLevelKey)];
+        } catch (DataException $ex) {
+            $userData = [];
+        }
+
+        try {
+            $schema    = $this->configSchemas[$topLevelKey];
             $processor = new Processor();
-            $processed = $processor->process($schema, $this->userConfig->export());
-            \assert($processed instanceof \stdClass);
+
+            $processed = $processor->process(Expect::structure([$topLevelKey => $schema]), $userData);
 
             $this->raiseAnyDeprecationNotices($processor->getWarnings());
 
-            return $this->finalConfig = new Data(self::convertStdClassesToArrays($processed));
+            $this->finalConfig->import((array) self::convertStdClassesToArrays($processed));
         } catch (NetteValidationException $ex) {
             throw new ValidationException($ex);
+        } catch (DataException $ex) {
+            // Do nothing
         }
     }
 
@@ -216,5 +234,24 @@ final class Configuration implements ConfigurationBuilderInterface, Configuratio
         foreach ($warnings as $warning) {
             @\trigger_error($warning, \E_USER_DEPRECATED);
         }
+    }
+
+    /**
+     * @throws InvalidPathException
+     */
+    private static function getTopLevelKey(string $path): string
+    {
+        if (\strlen($path) === 0) {
+            throw new InvalidPathException('Path cannot be an empty string');
+        }
+
+        $path = \str_replace(['.', '/'], '.', $path);
+
+        $firstDelimiter = \strpos($path, '.');
+        if ($firstDelimiter === false) {
+            return $path;
+        }
+
+        return \substr($path, 0, $firstDelimiter);
     }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -193,8 +193,6 @@ final class Configuration implements ConfigurationBuilderInterface, Configuratio
             $this->finalConfig->import((array) self::convertStdClassesToArrays($processed));
         } catch (NetteValidationException $ex) {
             throw new ValidationException($ex);
-        } catch (DataException $ex) {
-            // Do nothing
         }
     }
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -39,9 +39,13 @@ final class ConfigurationTest extends TestCase
 
         $config->addSchema('a', Expect::string()->required());
 
+        // Even though 'a' requires data, reading 'foo' should still work
+        $config->get('foo');
+
+        // But reading 'a' should fail
         try {
-            $config->get('foo');
-            $this->fail('A validation exception should be thrown since the full schema doesn\'t pass validation');
+            $config->get('a');
+            $this->fail('A validation exception should be thrown since the "a" schema doesn\'t pass validation');
         } catch (\Throwable $t) {
             $this->assertInstanceOf(ValidationException::class, $t);
         }
@@ -116,9 +120,8 @@ final class ConfigurationTest extends TestCase
             $this->fail('A validation exception should have been thrown');
         } catch (\Throwable $t) {
             $this->assertInstanceOf(ValidationException::class, $t);
-            $this->assertCount(2, $t->getMessages());
-            $this->assertStringContainsString("item 'foo' is missing", $t->getMessages()[0]);
-            $this->assertStringContainsString("item 'bar' expects to be int", $t->getMessages()[1]);
+            $this->assertCount(1, $t->getMessages());
+            $this->assertStringContainsString("item 'bar' expects to be int", $t->getMessages()[0]);
         }
     }
 
@@ -207,15 +210,12 @@ final class ConfigurationTest extends TestCase
         $config->get('foo');
     }
 
-    public function testSetUndefinedKey(): void
+    public function testSetUndefinedKeyDoesNotThrowException(): void
     {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessageMatches("/Unexpected item 'bar'/");
-
         $config = new Configuration(['foo' => Expect::int(42)]);
 
         $config->set('bar', 3);
-        $config->get('foo');
+        $this->assertSame(42, $config->get('foo'));
     }
 
     public function testSetNestedWhenOptionNotNested(): void


### PR DESCRIPTION
Fixes https://github.com/thephpleague/commonmark/issues/910 by changing how we perform delayed schema validation.

Previously, we delayed validation until the user request any config value. At this time, we'd validate the entire configuration against all registered schemas.  This could lead to issues if other, unrelated configs/schemas didn't have both the schema and data values registered at the time.

With this PR, we still delay validation, but that validation now only checks the relevant part of the configuration against the relevant schema.