### PR TITLE
Fix PHPStan failures

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -185,8 +185,8 @@ final class Configuration implements ConfigurationBuilderInterface, Configuratio
             $schema    = $this->configSchemas[$topLevelKey];
             $processor = new Processor();
 
-            /** @var \StdClass $processed */
             $processed = $processor->process(Expect::structure([$topLevelKey => $schema]), $userData);
+            \assert($processed instanceof \stdClass);
 
             $this->raiseAnyDeprecationNotices($processor->getWarnings());
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -17,7 +17,6 @@ use Dflydev\DotAccessData\Data;
 use Dflydev\DotAccessData\DataInterface;
 use Dflydev\DotAccessData\Exception\DataException;
 use Dflydev\DotAccessData\Exception\InvalidPathException;
-use Dflydev\DotAccessData\Exception\MissingPathException;
 use League\Config\Exception\UnknownOptionException;
 use League\Config\Exception\ValidationException;
 use Nette\Schema\Expect;
@@ -117,12 +116,8 @@ final class Configuration implements ConfigurationBuilderInterface, Configuratio
             $this->build(self::getTopLevelKey($key));
 
             return $this->cache[$key] = $this->finalConfig->get($key);
-        } catch (\Exception $ex) {
-            if ($ex instanceof InvalidPathException || $ex instanceof MissingPathException) {
-                throw new UnknownOptionException($ex->getMessage(), $key, (int) $ex->getCode(), $ex);
-            }
-
-            throw $ex;
+        } catch (InvalidPathException $ex) {
+            throw new UnknownOptionException($ex->getMessage(), $key, (int) $ex->getCode(), $ex);
         }
     }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -117,8 +117,12 @@ final class Configuration implements ConfigurationBuilderInterface, Configuratio
             $this->build(self::getTopLevelKey($key));
 
             return $this->cache[$key] = $this->finalConfig->get($key);
-        } catch (InvalidPathException | MissingPathException $ex) {
-            throw new UnknownOptionException($ex->getMessage(), $key, (int) $ex->getCode(), $ex);
+        } catch (\Exception $ex) {
+            if ($ex instanceof InvalidPathException || $ex instanceof MissingPathException) {
+                throw new UnknownOptionException($ex->getMessage(), $key, (int) $ex->getCode(), $ex);
+            }
+
+            throw $ex;
         }
     }
 
@@ -186,6 +190,7 @@ final class Configuration implements ConfigurationBuilderInterface, Configuratio
             $schema    = $this->configSchemas[$topLevelKey];
             $processor = new Processor();
 
+            /** @var \StdClass $processed */
             $processed = $processor->process(Expect::structure([$topLevelKey => $schema]), $userData);
 
             $this->raiseAnyDeprecationNotices($processor->getWarnings());

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -190,7 +190,7 @@ final class Configuration implements ConfigurationBuilderInterface, Configuratio
 
             $this->raiseAnyDeprecationNotices($processor->getWarnings());
 
-            $this->finalConfig->import((array) self::convertStdClassesToArrays($processed));
+            $this->finalConfig->import(self::convertStdClassesToArrays($processed));
         } catch (NetteValidationException $ex) {
             throw new ValidationException($ex);
         }


### PR DESCRIPTION
This is a fix. Resolves #23 

Errors:

PHPStan: src/Configuration.php#L120 Dead catch - Dflydev\DotAccessData\Exception\MissingPathException is never thrown in the try block.

PHPStan: src/Configuration.php#L193 Parameter 1 $data of method Dflydev\DotAccessData\Data::import() expects array<string, mixed>, array given.